### PR TITLE
Make it compile with GHC 7.8

### DIFF
--- a/ConstMath/Pass.hs
+++ b/ConstMath/Pass.hs
@@ -146,7 +146,8 @@ mkUnaryCollapseNum fnE opts expr@(App f1 (App f2 (Lit lit)))
             | otherwise = do
                 let sub = fnE (from d)
                 msgResult
-                return (App f2 (mkLit sub))
+                dflags <- getDynFlags
+                return (App f2 (mkLit dflags sub))
 mkUnaryCollapseNum _ _ expr = return expr
 
 mkBinaryCollapse :: (forall a. RealFloat a => (a -> a -> a))

--- a/ConstMath/Pass.hs
+++ b/ConstMath/Pass.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 
 {-# OPTIONS_GHC -Wall #-}
 module ConstMath.Pass (

--- a/tests/Make.hs
+++ b/tests/Make.hs
@@ -1,7 +1,7 @@
 module Main where
 
-import System.Cmd
 import System.Directory
+import System.Process
 
 import Paths_const_math_ghc_plugin
 


### PR DESCRIPTION
The mkIntLitInt type change breaks building with GHC < 7.8. I don't know if that is the best way to fix it either. Feedback requested.
